### PR TITLE
Remove scipy version limit

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,20 +8,20 @@ package:
 source:
   git_url: https://github.com/csdms-contrib/anuga_BMI
 
+build:
+  number: 1
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
 requirements:
   build:
     - cython
     - anuga
-    - scipy <=0.18.1
+    - scipy
   run:
     - anuga
     - pyyaml
     - basic-modeling-interface
-    - scipy <=0.18.1
-
-build:
-  number: 0
-  script: python setup.py install --single-version-externally-managed --record record.txt
+    - scipy
 
 test:
 


### PR DESCRIPTION
The limit I had placed on the scipy version (see https://github.com/csdms-stack/anugased-rectangular-recipe/commit/d48a2c6dde3f8b2f029dc5ea8579df7651bcae38) is no longer needed, and, in fact, was causing the build to fail.